### PR TITLE
Fix convert call

### DIFF
--- a/gptspeak/cli.py
+++ b/gptspeak/cli.py
@@ -175,7 +175,7 @@ def convert(input_file, output, model, voice):
         default_model, default_voice = get_config()
         model = model or default_model
         voice = voice or default_voice
-        convert_text_to_speech(input_file, output, model, voice, api_key)
+        convert_text_to_speech(input_file, output, model, voice)
         click.echo(f"Successfully converted {input_file} to {output}")
     except APIConfigError as e:
         click.echo(str(e), err=True)


### PR DESCRIPTION
I was getting this error...

```
❯ : gptspeak convert ./input.txt
2025-01-20 16:04:22 - root - ERROR - Error during conversion: convert_text_to_s
 were given
Error: convert_text_to_speech() takes 4 positional arguments but 5 were given
```

I realized the `convert` call is not working on main because the `convert_text_to_speech` call no longer takes the api_key as an argument. After I removed the fifth argument all is working as expected.

P.S. Thanks for all your great work on this library. Very helpful!